### PR TITLE
Adding new macro's to Filament Table Summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Filament V3 unlike V2 that uses [laravel-money](https://github.com/akaunting/lar
 
 This package will add a new `currency(string | Closure $currency = null, bool $shouldConvert = false)` method to the `TextColumn` that uses the Filament V2 money formatter.
 
+Additionally, you can use the `currency(string | Closure $currency = null, bool $shouldConvert = false)` method when adding Summarizers to the table. Currently this method only exists for the `Sum` and `Average` Summarizer.
+
 By using this package you can configure the formatter using [laravel-money config](https://github.com/akaunting/laravel-money/blob/master/config/money.php).
 
 For example, you can customize the `symbol`, `symbol_first`, `decimal_mark`, and `thousands_separator` for each currency. Or if you want you can add your custom currency to the config and use it in the `currency()` method instead of standard money.
@@ -32,6 +34,14 @@ php artisan vendor:publish --tag=money
 ```php
 \Filament\Tables\Columns\TextColumn::make('money')
     ->currency('USD');
+
+\Filament\Tables\Columns\TextColumn::make('money')
+    ->currency('USD')
+    ->summarize(\Filament\Tables\Columns\Summarizers\Sum::make()->currency());
+
+\Filament\Tables\Columns\TextColumn::make('money')
+    ->currency('USD')
+    ->summarize(\Filament\Tables\Columns\Summarizers\Average::make()->currency());
 
 \Filament\Forms\Components\TextInput::make('money')
     ->currencyMask(thousandSeparator: ',',decimalSeparator: '.',precision: 2)

--- a/ide-helper.stubs.php
+++ b/ide-helper.stubs.php
@@ -22,3 +22,22 @@ namespace Filament\Forms\Components {
         }
     }
 }
+namespace Filament\Tables\Columns\Summarizers {
+
+    use Closure;
+
+    class Average
+    {
+        public function currency(string | Closure | null $currency = null, bool $shouldConvert = false): self
+        {
+            return $this;
+        }
+    }
+    class Sum
+    {
+        public function currency(string | Closure | null $currency = null, bool $shouldConvert = false): self
+        {
+            return $this;
+        }
+    }
+}

--- a/src/FilamentCurrencyServiceProvider.php
+++ b/src/FilamentCurrencyServiceProvider.php
@@ -9,8 +9,7 @@ use Filament\Tables\Columns\Column;
 use Filament\Tables\Columns\TextColumn;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use Filament\Tables\Columns\Summarizers\Sum;
-use Filament\Tables\Columns\Summarizers\Summarizer;
+use Filament\Tables\Columns\Summarizers;
 
 class FilamentCurrencyServiceProvider extends PackageServiceProvider
 {
@@ -57,8 +56,28 @@ class FilamentCurrencyServiceProvider extends PackageServiceProvider
             return $this;
         });
 
-        Sum::macro('currency', function (string | Closure | null $currency = null, bool $shouldConvert = false): Sum {
-            $this->formatStateUsing(static function (Summarizer $summarizer, $state) use ($currency, $shouldConvert): ?string {
+        Summarizers\Sum::macro('currency', function (string | Closure | null $currency = null, bool $shouldConvert = false): Summarizers\Sum {
+            $this->formatStateUsing(static function (Summarizers\Summarizer $summarizer, $state) use ($currency, $shouldConvert): ?string {
+                if (blank($state)) {
+                    return null;
+                }
+
+                if (blank($currency)) {
+                    $currency = config('filament-currency.default_currency');
+                }
+
+                return (new Money\Money(
+                    $state,
+                    (new Money\Currency(strtoupper($summarizer->evaluate($currency)))),
+                    $shouldConvert,
+                ))->format();
+            });
+
+            return $this;
+        });
+
+        Summarizers\Average::macro('currency', function (string | Closure | null $currency = null, bool $shouldConvert = false): Summarizers\Average {
+            $this->formatStateUsing(static function (Summarizers\Summarizer $summarizer, $state) use ($currency, $shouldConvert): ?string {
                 if (blank($state)) {
                     return null;
                 }


### PR DESCRIPTION
With this new macro the developer can now use the currency conversion for Filament Table Summarizer. Currently the 2 macros are added to `Sum` and `Average` Summarizer classes. Documentation was also updated to reflect these changes. Also refactored the code to remove code duplication by adding a anonymous static function that gets called inside each macro.