### PR TITLE
Adding a new macro to format TextEntry for Infolists

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,26 @@
 
 Filament V3 unlike V2 that uses [laravel-money](https://github.com/akaunting/laravel-money) package for formatting money TextColumns uses PHP native [NumberFormatter](https://www.php.net/manual/en/class.numberformatter.php) class.
 
-This package will add a new `currency(string | Closure $currency = null, bool $shouldConvert = false)` method to the `TextColumn` that uses the Filament V2 money formatter.
+### Text Column (Table Builder)
 
-Additionally, you can use the `currency(string | Closure $currency = null, bool $shouldConvert = false)` method when adding Summarizers to the table. Currently this method only exists for the `Sum` and `Average` Summarizer.
+A new `currency(string | Closure $currency = null, bool $shouldConvert = false)` method to the `TextColumn` that uses the Filament V2 money formatter.
+
+### Summary (Table Builder)
+
+The summarizer classes `Sum` and `Average` contains the method `currency(string | Closure $currency = null, bool $shouldConvert = false)` to display the value in the configured currency format.
+
+### Text Entry (InfoLists)
+
+A new `currency(string | Closure $currency = null, bool $shouldConvert = false)` method to the `TextEntry`
+
+### Text Input (Form Builder)
+
+We also have a `currencyMask()` method for `TextInput` that lets you mask your numbers in front-end and return the plain number to back-end.
 
 By using this package you can configure the formatter using [laravel-money config](https://github.com/akaunting/laravel-money/blob/master/config/money.php).
 
 For example, you can customize the `symbol`, `symbol_first`, `decimal_mark`, and `thousands_separator` for each currency. Or if you want you can add your custom currency to the config and use it in the `currency()` method instead of standard money.
 
-We also have a `currencyMask()` method for `TextInput` that lets you mask your numbers in front-end and return the plain number to back-end.
 ## Installation
 
 You can install the package via Composer:
@@ -42,6 +53,9 @@ php artisan vendor:publish --tag=money
 \Filament\Tables\Columns\TextColumn::make('money')
     ->currency('USD')
     ->summarize(\Filament\Tables\Columns\Summarizers\Average::make()->currency());
+
+\Filament\Infolists\Components\TextEntry::make('money')
+    ->currency('USD');
 
 \Filament\Forms\Components\TextInput::make('money')
     ->currencyMask(thousandSeparator: ',',decimalSeparator: '.',precision: 2)

--- a/ide-helper.stubs.php
+++ b/ide-helper.stubs.php
@@ -14,6 +14,7 @@ namespace Filament\Tables\Columns {
 }
 
 namespace Filament\Forms\Components {
+    
     class TextInput
     {
         public function currencyMask($thousandSeparator = ',', $decimalSeparator = '.', $precision = 2): self
@@ -35,6 +36,19 @@ namespace Filament\Tables\Columns\Summarizers {
         }
     }
     class Sum
+    {
+        public function currency(string | Closure | null $currency = null, bool $shouldConvert = false): self
+        {
+            return $this;
+        }
+    }
+}
+
+namespace Filament\Infolists\Components {
+
+    use Closure;
+
+    class TextEntry
     {
         public function currency(string | Closure | null $currency = null, bool $shouldConvert = false): self
         {

--- a/src/FilamentCurrencyServiceProvider.php
+++ b/src/FilamentCurrencyServiceProvider.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Tables\Columns\Column;
 use Filament\Tables\Columns\Summarizers;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Infolists\Components\TextEntry;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -41,6 +42,7 @@ class FilamentCurrencyServiceProvider extends PackageServiceProvider
                 $shouldConvert,
             ))->format();
         };
+        
         TextColumn::macro('currency', function (string | Closure | null $currency = null, bool $shouldConvert = false) use ($formatter): TextColumn {
             /**
              * @var TextColumn $this
@@ -83,6 +85,19 @@ class FilamentCurrencyServiceProvider extends PackageServiceProvider
             $this->formatStateUsing(static function (Summarizers\Summarizer $summarizer, $state) use ($currency, $shouldConvert, $formatter): ?string {
 
                 return $formatter($state, $summarizer, $currency, $shouldConvert);
+
+            });
+
+            return $this;
+        });
+
+        TextEntry::macro('currency', function (string | Closure | null $currency = null, bool $shouldConvert = false) use ($formatter): TextEntry {
+            /**
+             * @var TextEntry $this
+             */
+            $this->formatStateUsing(static function (TextEntry $column, $state) use ($currency, $shouldConvert, $formatter): ?string {
+
+                return $formatter($state, $column, $currency, $shouldConvert);
 
             });
 


### PR DESCRIPTION
This new macro adds the `currency` method to the TextEntry class similar to the other components in this package.
The documentation and the `ide_stub` has been updated to reflect these changes