### PR TITLE
Fixes money not rendering properly on reload due to not firing input …

### DIFF
--- a/resources/views/currency-mask.blade.php
+++ b/resources/views/currency-mask.blade.php
@@ -19,14 +19,17 @@
     {
         input:\$wire.{$applyStateBindingModifiers("\$entangle('{$statePath}')")},
         masked:'',
-        init(){
-        \$nextTick(()=>this.masked = this.input?.toString().replaceAll('.','$decimalSeparator'));
-        \$watch('masked',()=>this.updateInput());
-        \$watch('input',()=>this.updateMasked());
+        init() {
+            \$nextTick(() => {
+                this.updateMasked();
+            });
+            \$watch('masked', () => this.updateInput());
+            \$watch('input', () => this.updateMasked());
         },
         updateMasked(){
             if(typeof Number(this.input) === 'number'){
                 \$el.value = this.input?.toString().replaceAll('.','$decimalSeparator');
+                this.masked = \$el.value;
                 \$el.dispatchEvent(new Event('input'));
             }
         },


### PR DESCRIPTION
This will fix the described issue that can be found here:
https://github.com/ariaieboy/filament-currency/issues/25

Not much changes except for the input event will also dispatch on load due to calling updateMasked.
Also improves readability and less duplication.

If merging, create a new release please :)


Note:
`if(typeof Number(this.input) === 'number'){`

This may be redundant, not sure though haven't checked.