### PR TITLE
Fix issue on live typing it jumps due to not dispatching input event

### DIFF
--- a/resources/views/currency-mask.blade.php
+++ b/resources/views/currency-mask.blade.php
@@ -20,14 +20,17 @@
         input:\$wire.{$applyStateBindingModifiers("\$entangle('{$statePath}')")},
         masked:'',
         init(){
-        \$nextTick(this.updateMasked());
-        \$watch('masked',()=>this.updateInput());
-        \$watch('input', () => this.updateMasked());
+            \$nextTick(this.updateMasked());
+            \$watch('masked', () => this.updateInput());
+            \$watch('input', () => this.updateMasked());
         },
-        updateMasked(value, oldValue){
+        updateMasked(){
             if(this.input !== undefined && typeof Number(this.input) === 'number') {
-                if(this.masked?.replaceAll('$thousandSeparator','').replaceAll('$decimalSeparator','.') != this.input){
+                let normalizedMasked = this.masked?.replaceAll('$thousandSeparator', '').replaceAll('$decimalSeparator', '.');
+
+                if (normalizedMasked != this.input?.toString()) {
                     this.masked = this.input?.toString().replaceAll('.','$decimalSeparator');
+                    \$el.dispatchEvent(new Event('input'));
                 }
             }
         },


### PR DESCRIPTION
See issue #32 
Please check this in issue #31 test branch to see if this works for that scenario aswell.

I checked myself by trying $set in afterStateUpdated on another input in my form.
In the repeater aswell, both work for me.

But should maybe check if this works in the old issue test branch.