### PR TITLE
Fixes type not to text when using numeric

### DIFF
--- a/resources/views/currency-mask.blade.php
+++ b/resources/views/currency-mask.blade.php
@@ -49,22 +49,6 @@
     }
 JS;
 
-    if ($isPasswordRevealable) {
-        $xData = '{ isPasswordRevealed: false }';
-    } elseif (count($extraAlpineAttributes) || filled($mask)) {
-        $xData = '{}';
-    } else {
-        $xData = null;
-    }
-
-    if ($isPasswordRevealable) {
-        $type = null;
-    } elseif (filled($mask)) {
-        $type = 'text';
-    } else {
-        $type = $getType();
-    }
-
     $inputAttributes = $getExtraInputAttributeBag()
         ->merge($extraAlpineAttributes, escape: false)
         ->merge([
@@ -85,7 +69,7 @@ JS;
             'readonly' => $isReadOnly(),
             'required' => $isRequired() && (! $isConcealed),
             'step' => $getStep(),
-            'type' => $type,
+            'type' => 'text',
             $xmodel =>'masked',
             'x-data' => $xdata,
             'x-bind:type' => $isPasswordRevealable ? 'isPasswordRevealed ? \'text\' : \'password\'' : null,


### PR DESCRIPTION
The blade file looks for the input type using the native `getType()`

This, however, breaks the masking javascript if used with `numeric()` or `integer()` validations on filament.
I removed the check to always use the `text` type when masking, this should be the default behaviour and it worked that way in the previous version.

Let me know if any more changes are needed
